### PR TITLE
chore(rules): tighten jsx-max-props-per-line to one prop per multiline

### DIFF
--- a/.changeset/pr-9.md
+++ b/.changeset/pr-9.md
@@ -1,0 +1,5 @@
+---
+"eslint-config-trendmicro": patch
+---
+
+chore(rules): tighten `jsx-max-props-per-line` to one prop per multiline

--- a/rules/react.js
+++ b/rules/react.js
@@ -13,7 +13,7 @@ export default {
     'react/jsx-fragments': 1,
     'react/jsx-indent': [2, 2],
     'react/jsx-indent-props': [2, 2],
-    'react/jsx-max-props-per-line': [1, { 'maximum': 3 }],
+    'react/jsx-max-props-per-line': [1, { maximum: 1, when: 'multiline' }],
     'react/jsx-no-bind': [1, {
       'ignoreRefs': true
     }],


### PR DESCRIPTION
## Summary

Allows any number of props on a single line but requires one prop per line when the JSX element spans multiple lines.