### PR TITLE
chore(rules): drop `assert` from `no-console` allow list

### DIFF
--- a/.changeset/pr-11.md
+++ b/.changeset/pr-11.md
@@ -1,0 +1,5 @@
+---
+"eslint-config-trendmicro": patch
+---
+
+chore(rules): drop `assert` from `no-console` allow list

--- a/rules/base.js
+++ b/rules/base.js
@@ -30,7 +30,7 @@ export default {
     'no-const-assign': 2,
     'no-constant-binary-expression': 1,
     'no-constructor-return': 0,
-    'no-console': [1, { 'allow': ['assert', 'warn', 'error'] }],
+    'no-console': [1, { 'allow': ['warn', 'error'] }],
     'no-continue': 0,
     'no-else-return': 0,
     'no-extra-boolean-cast': 0,


### PR DESCRIPTION
## Summary
- Remove `assert` from the `no-console` rule's `allow` list in `rules/base.js`
- Tightens the rule to only permit `console.warn` and `console.error`, which are the legitimate channels for signaling problems in production code

## Test plan
- [ ] Verify ESLint config loads without errors in consumer projects
- [ ] Confirm `console.assert(...)` now triggers the `no-console` warning
- [ ] Confirm `console.warn(...)` and `console.error(...)` remain allowed