### PR TITLE
chore(rules): allow components as props for `react/no-unstable-nested-components`

### DIFF
--- a/.changeset/pr-19.md
+++ b/.changeset/pr-19.md
@@ -1,0 +1,5 @@
+---
+"eslint-config-trendmicro": minor
+---
+
+chore(rules): allow components as props for `react/no-unstable-nested-components`

--- a/rules/react.js
+++ b/rules/react.js
@@ -39,7 +39,7 @@ export default {
     'react/no-typos': 1,
     'react/no-unknown-property': 1,
     'react/no-unsafe': 1,
-    'react/no-unstable-nested-components': 1,
+    'react/no-unstable-nested-components': [1, { allowAsProps: true }],
     'react/no-unused-prop-types': 0,
     'react/no-unused-state': 0,
     'react/prefer-stateless-function': 1,


### PR DESCRIPTION
## Summary
- Enable `allowAsProps: true` on `react/no-unstable-nested-components` so components passed as props are not flagged.

## Test plan
- [ ] `yarn test`
- [ ] `yarn lint`