### PR TITLE
chore(rules): allow destructured state for `react/hook-use-state`

### DIFF
--- a/.changeset/pr-21.md
+++ b/.changeset/pr-21.md
@@ -1,0 +1,5 @@
+---
+"eslint-config-trendmicro": patch
+---
+
+chore(rules): allow destructured state for `react/hook-use-state`

--- a/rules/react.js
+++ b/rules/react.js
@@ -5,7 +5,7 @@ export default {
     'react/destructuring-assignment': 0,
     'react/forbid-prop-types': 0,
     'react/function-component-definition': 0,
-    'react/hook-use-state': 1,
+    'react/hook-use-state': [1, { allowDestructuredState: true }],
     'react/iframe-missing-sandbox': 1,
     'react/jsx-boolean-value': 0,
     'react/jsx-curly-spacing': 1,


### PR DESCRIPTION
## Summary
- Enable `allowDestructuredState: true` option on `react/hook-use-state` to permit destructuring the value returned from `useState` (e.g. `const [{ foo, bar }, setState] = useState({ foo: 1, bar: 2 })`).

## Test plan
- [ ] `yarn test`
- [ ] `yarn eslint`