### PR TITLE
chore: add changeset for PR #22

### DIFF
--- a/.changeset/pr-22.md
+++ b/.changeset/pr-22.md
@@ -1,0 +1,5 @@
+---
+"eslint-config-trendmicro": minor
+---
+
+chore(rules): tune severities, add import rules, normalize style


### PR DESCRIPTION
## Summary

Adds the changeset for [#22](https://github.com/trendmicro-frontend/eslint-config-trendmicro/pull/22) which was merged without one.

Covers: severity tuning across `base.js`, `import.js`, `jsx-a11y.js`, `react.js`, `stylistic.js`, plus style normalization (bare keys in option objects).

## Test plan

- [ ] `yarn test` passes