### PR TITLE
chore(rules): disable no-shadow, tune prefer-const

### DIFF
--- a/.changeset/lovely-coats-sniff.md
+++ b/.changeset/lovely-coats-sniff.md
@@ -1,0 +1,5 @@
+---
+"eslint-config-trendmicro": patch
+---
+
+chore(rules): disable `no-shadow`, tune `prefer-const`

--- a/rules/base.js
+++ b/rules/base.js
@@ -37,7 +37,7 @@ export default {
     'no-restricted-properties': 0,
     'no-restricted-syntax': 0,
     'no-return-await': 0,
-    'no-shadow': 1,
+    'no-shadow': 0,
     'no-underscore-dangle': 0,
     'no-unused-expressions': [2, {
       allowShortCircuit: true,
@@ -65,7 +65,7 @@ export default {
     'no-var': 2,
     'object-shorthand': 0,
     'one-var': 0,
-    'prefer-const': 1,
+    'prefer-const': [1, { destructuring: 'all' }],
     'prefer-destructuring': 0,
     'prefer-object-has-own': 0,
     'prefer-object-spread': 0,


### PR DESCRIPTION
## Summary

- Turn off `no-shadow` — produces too much noise in practice
- Relax `prefer-const` with `destructuring: 'all'` so it only flags destructured groups where every binding is never reassigned

## Test plan

- [ ] `yarn test` passes
- [ ] No new lint errors on downstream projects